### PR TITLE
chore: Adding acronymbot as new service in my dev commons

### DIFF
--- a/marcelo.planx-pla.net/manifest.json
+++ b/marcelo.planx-pla.net/manifest.json
@@ -27,7 +27,8 @@
     "sheepdog": "quay.io/cdis/sheepdog:master",
     "spark": "quay.io/cdis/gen3-spark:master",
     "wts": "quay.io/cdis/workspace-token-service:master",
-    "tube": "quay.io/cdis/tube:master"
+    "tube": "quay.io/cdis/tube:master",
+    "acronymbot": "quay.io/cdis/acronym-bot:master"
   },
   "arborist": {
     "deployment_version": "2"


### PR DESCRIPTION
Introducing new service to my dev commons.
The `acronymbot` app is a Slack bot that expands CTDS acronyms.