### PR TITLE
chore(michael): remove deprecated section

### DIFF
--- a/mlukowski.planx-pla.net/manifest.json
+++ b/mlukowski.planx-pla.net/manifest.json
@@ -39,9 +39,6 @@
   "jupyterhub": {
     "enabled": "yes"
   },
-  "tube": {
-    "es_index_name": "michael"
-  },
   "sower": [
     {
       "name": "pelican-export",


### PR DESCRIPTION
### Environments
* `michael`

### Description of changes
* Remove deprecated section for `tube` from the manifest