### PR TITLE
changes to the etlMapping file in dev in order to fix etl runs.

### DIFF
--- a/dev.planx-pla.net/etlMapping.yaml
+++ b/dev.planx-pla.net/etlMapping.yaml
@@ -50,7 +50,7 @@ mappings:
         fn: count
     joining_props:
       - index: file
-        join_on: case_id
+        join_on: _case_id
         props:
           - name: data_format
             src: data_format
@@ -58,8 +58,8 @@ mappings:
           - name: data_type
             src: data_type
             fn: set
-          - name: file_id
-            src: file_id
+          - name: _file_id
+            src: _file_id
             fn: set
   - name: dev_file
     doc_type: file
@@ -77,10 +77,11 @@ mappings:
     injecting_props:
       case:
         props:
-          - name: case_id
+          - name: _case_id
             src: id
             fn: set
           - name: project_id
     target_nodes:
       - name: slide_image
         path: slides.samples.cases
+        


### PR DESCRIPTION
guppy and etl runs were broken in devplanetv1, so this is the fix I implemented in order to have the Explorer page render. 