### PR TITLE
upgrading the tube and guppy version 

### DIFF
--- a/emalinowskiv1.planx-pla.net/etlMapping.yaml
+++ b/emalinowskiv1.planx-pla.net/etlMapping.yaml
@@ -1,19 +1,25 @@
 mappings:
-  - name: etl
+  - name: dev_case
     doc_type: case
     type: aggregator
     root: case
     props:
       - name: submitter_id
       - name: project_id
-      - name: experimental_group
+      - name: disease_type
+      - name: primary_site
     flatten_props:
       - path: demographics
         props:
           - name: gender
+            value_mappings:
+              - female: F
+              - male: M
           - name: race
+            value_mappings:
+              - american indian or alaskan native: Indian
           - name: ethnicity
-        sorted_by: updated_datetime, desc
+          - name: year_of_birth
     aggregated_props:
       - name: _samples_count
         path: samples
@@ -21,12 +27,60 @@ mappings:
       - name: _aliquots_count
         path: samples.aliquots
         fn: count
-      - name: _read_group_count
+      - name: _submitted_methylations_count
+        path: samples.aliquots.submitted_methylation_files
+        fn: count
+      - name: _submitted_copy_number_files_on_aliquots_count
+        path: samples.aliquots.submitted_copy_number_files
+        fn: count
+      - name: _read_groups_count
         path: samples.aliquots.read_groups
         fn: count
-      - name: _submitted_expression_arrays_count
-        path: samples.aliquots.submitted_expression_array_files
+      - name: _submitted_aligned_reads_count
+        path: samples.aliquots.read_groups.submitted_aligned_reads_files
         fn: count
       - name: _submitted_unaligned_reads_count
         path: samples.aliquots.read_groups.submitted_unaligned_reads_files
         fn: count
+      - name: _submitted_copy_number_files_on_read_groups_count
+        path: samples.aliquots.read_groups.submitted_copy_number_files
+        fn: count
+      - name: _submitted_somatic_mutations_count
+        path: samples.aliquots.read_groups.submitted_somatic_mutations
+        fn: count
+    joining_props:
+      - index: file
+        join_on: _case_id
+        props:
+          - name: data_format
+            src: data_format
+            fn: set
+          - name: data_type
+            src: data_type
+            fn: set
+          - name: _file_id
+            src: _file_id
+            fn: set
+  - name: dev_file
+    doc_type: file
+    type: collector
+    root: None
+    category: data_file
+    props:
+      - name: object_id
+      - name: md5sum
+      - name: file_name
+      - name: file_size
+      - name: data_format
+      - name: data_type
+      - name: state
+    injecting_props:
+      case:
+        props:
+          - name: _case_id
+            src: id
+            fn: set
+          - name: project_id
+    target_nodes:
+      - name: slide_image
+        path: slides.samples.cases

--- a/emalinowskiv1.planx-pla.net/manifest.json
+++ b/emalinowskiv1.planx-pla.net/manifest.json
@@ -24,7 +24,7 @@
     "sheepdog": "quay.io/cdis/sheepdog:master",
     "sower": "quay.io/cdis/sower:master",
     "spark": "quay.io/cdis/gen3-spark:master",
-    "tube": "quay.io/cdis/tube:master",
+    "tube": "quay.io/cdis/tube:feat/es-8",
     "dashboard": "quay.io/cdis/gen3-statics:master"
   },
   "arborist": {
@@ -156,6 +156,18 @@
   },
   "jupyterhub": {
     "enabled": "yes"
+  },
+  "guppy": {
+    "indices": [
+      {
+        "index": "dev_case",
+        "type": "case"
+      },
+      {
+        "index": "dev_file",
+        "type": "file"
+      }
+    ]
   },
   "global": {
     "environment": "devplanetv1",

--- a/emalinowskiv1.planx-pla.net/manifest.json
+++ b/emalinowskiv1.planx-pla.net/manifest.json
@@ -24,7 +24,7 @@
     "sheepdog": "quay.io/cdis/sheepdog:master",
     "sower": "quay.io/cdis/sower:master",
     "spark": "quay.io/cdis/gen3-spark:master",
-    "tube": "quay.io/cdis/tube:feat/es-8",
+    "tube": "quay.io/cdis/tube:feat_es-8",
     "dashboard": "quay.io/cdis/gen3-statics:master"
   },
   "arborist": {


### PR DESCRIPTION
In order to test the ES update from V 6.8 to V 7.10, I need to have the etl job run properly. I added a "guppy" block to the manifest.json and added the proper etlMapping (used devplanet1 as reference). 

Also, upgraded the tube and guppy version per GPE-873 to test creating the new ES 7.10 indices. 